### PR TITLE
THROW was an internal, use .throw instead

### DIFF
--- a/lib/Format/Lisp/Actions.pm6
+++ b/lib/Format/Lisp/Actions.pm6
@@ -1034,7 +1034,7 @@ class Format::Lisp::Actions {
 			make $/<tilde-X>.ast
 		}
 		elsif $/<tilde-Unused> {
-			THROW X::Format-Error.new;
+			X::Format-Error.new.throw;
 		}
 	}
 


### PR DESCRIPTION
sub THROW was removed, because it was no longer used.  Replace it with calling the `throw` method instead.  Passes all tests.